### PR TITLE
supports subtable format 14 in cmap

### DIFF
--- a/t/uvs.t
+++ b/t/uvs.t
@@ -1,0 +1,48 @@
+#!perl
+
+use strict;
+
+my $font;
+BEGIN {
+    ($font) = grep -f, (
+        "/usr/share/fonts/opentype/ipaexfont-gothic/ipaexg.ttf", # ubuntu
+        "/usr/local/share/fonts/OTF/ipaexg.otf", # freebsd
+    );
+}
+
+use Test::Simple $font ? (tests => 3) : (skip_all => "Cannot find a font containing a format 14");
+use Font::TTF::Font;
+use File::Temp qw/tempfile/;
+
+my $f = Font::TTF::Font->open($font);
+ok $f, "open font: $font";
+$f->{'cmap'}->read;
+
+my ($tmp, $tempfile) = tempfile();
+$f->{'cmap'}->out($tmp);
+
+my $g = Font::TTF::Font->open($font);
+ok $g, "open font: $font";
+
+# setup $tempfile for cmap
+$g->{'cmap'}{' INFILE'} = $tmp;
+$g->{'cmap'}{' LENGTH'} = $tmp->tell();
+$g->{'cmap'}{' OFFSET'} = 0;
+$g->{'cmap'}{' ZLENGTH'} = 0;
+$g->{'cmap'}{' INFILE'}->seek(0, 0);
+$g->{'cmap'}->read;
+
+my $unmatch = 0;
+for (sort keys %{$f->{cmap}->find_uvs->{val}}) {
+    my $fid = $f->{cmap}->uvs_lookup($_);
+    my $gid = $g->{cmap}->uvs_lookup($_);
+    $unmatch++ unless $fid == $gid;
+}
+for (sort keys %{$g->{cmap}->find_uvs->{val}}) {
+    my $fid = $f->{cmap}->uvs_lookup($_);
+    my $gid = $g->{cmap}->uvs_lookup($_);
+    $unmatch++ unless $fid == $gid;
+}
+ok !$unmatch, 'match: table of format 14, read() after out()';
+
+unlink $tempfile;

--- a/t/uvs.t
+++ b/t/uvs.t
@@ -5,18 +5,21 @@ use strict;
 my $font;
 BEGIN {
     ($font) = grep -f, (
+        #"../noto/SauceHanSansJP-Regular.TTF",
         "/usr/share/fonts/opentype/ipaexfont-gothic/ipaexg.ttf", # ubuntu
         "/usr/local/share/fonts/OTF/ipaexg.otf", # freebsd
     );
 }
 
-use Test::Simple $font ? (tests => 3) : (skip_all => "Cannot find a font containing a format 14");
+use Test::More $font ? (tests => 4) : (skip_all => "Cannot find a font containing a format 14");
 use Font::TTF::Font;
 use File::Temp qw/tempfile/;
 
 my $f = Font::TTF::Font->open($font);
 ok $f, "open font: $font";
 $f->{'cmap'}->read;
+
+ok $f->{'cmap'}->find_uvs, "$font has uvstable";
 
 my ($tmp, $tempfile) = tempfile();
 $f->{'cmap'}->out($tmp);
@@ -33,16 +36,21 @@ $g->{'cmap'}{' INFILE'}->seek(0, 0);
 $g->{'cmap'}->read;
 
 my $unmatch = 0;
-for (sort keys %{$f->{cmap}->find_uvs->{val}}) {
-    my $fid = $f->{cmap}->uvs_lookup($_);
-    my $gid = $g->{cmap}->uvs_lookup($_);
-    $unmatch++ unless $fid == $gid;
+for my $uvs (keys %{$f->{cmap}->find_uvs->{val}}) {
+    for my $uni (keys %{$f->{cmap}->find_uvs->{val}{$uvs}}) {
+        my $fid = $f->{cmap}->uvs_lookup($uvs, $uni);
+        my $gid = $g->{cmap}->uvs_lookup($uvs, $uni);
+        $unmatch++ unless $fid == $gid;
+    }
 }
-for (sort keys %{$g->{cmap}->find_uvs->{val}}) {
-    my $fid = $f->{cmap}->uvs_lookup($_);
-    my $gid = $g->{cmap}->uvs_lookup($_);
-    $unmatch++ unless $fid == $gid;
+for my $uvs (keys %{$g->{cmap}->find_uvs->{val}}) {
+    for my $uni (keys %{$g->{cmap}->find_uvs->{val}{$uvs}}) {
+        my $fid = $f->{cmap}->uvs_lookup($uvs, $uni);
+        my $gid = $g->{cmap}->uvs_lookup($uvs, $uni);
+        $unmatch++ unless $fid == $gid;
+    }
 }
+
 ok !$unmatch, 'match: table of format 14, read() after out()';
 
 unlink $tempfile;


### PR DESCRIPTION
Use code and selector as hash keys in the Format 14 Unicode Variation Sequences table:

```
$gid = $font->{'cmap'}->{'Tables'}[0]{'val'}{$code, $selector};
```

To test with t/uvs.t, you must install the ipaexfont (which supports UVS).

```
(ubuntu)$ sudo apt install fonts-ipaexfont
(freebsd)$ sudo pkg install ja-fonts-ipaex
```

Example usage, you can use UVS to create a groff text map with the following code:

```
for (keys %{$f->{cmap}->find_uvs->{val}}) {
    next unless my $gid = $f->{cmap}->uvs_lookup($_);
    printf "%s u%04X_%04X\n", $f->{post}{VAL}[$gid], s split $;;
}
```

thanks
